### PR TITLE
Add eclipse-score.github.io repo

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -7,5 +7,28 @@ orgs.newOrg('eclipse-score') {
     },
   },
   _repositories+:: [
+    orgs.newRepo('eclipse-score.github.io') {
+      description: "The landing page website for the Score project",
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      delete_branch_on_merge: false,
+      homepage: "https://eclipse-score.github.io/",
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+      gh_pages_build_type: "workflow",
+      has_discussions: false,
+      topics+: [
+        "landing-page",
+        "score"
+      ],
+      web_commit_signoff_required: false,
+    }
   ],
 }


### PR DESCRIPTION
Adds landing page repository that will use custom workflow for building the github-pages content.