### PR TITLE
docs: enable pull requests to publish a preview

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -317,6 +317,11 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       topics+: [
         "score"
       ],
+      workflows: {
+        # Allow actions to publish documentation from pull requests.
+        # Note: 'default' is also the 'maximum', it cannot be elevated by actions unless the default is 'write'.
+        default_workflow_permissions: "write",
+      },
       rulesets: [
         orgs.newRepoRuleset('main') {
           include_refs+: [

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -317,7 +317,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       topics+: [
         "score"
       ],
-      workflows: {
+      workflows+: {
         # Allow actions to publish documentation from pull requests.
         # Note: 'default' is also the 'maximum', it cannot be elevated by actions unless the default is 'write'.
         default_workflow_permissions: "write",


### PR DESCRIPTION
We have an action running, which will publish pull request previews into /pr-123 subdirectories in gh-pages. However that action currently cannot push to gh-pages branch.

GITHUB_TOKEN is currently allowed to push to branches when running for branch builds, but it's disabled when running from PR builds. This PR adjusts the relevant setting.

note: there is contradicting information on the internet regarding how 'default workflow permissions' behave. But it seems (as evidenced in this case), that the interpretation of it serving as a maximum is correct. Workflows cannot elevate themselves to write, when the default is set to read-only.

> If your repository's Actions permissions setting is set to "Read repository contents permission" (default), the permissions block in the workflow cannot elevate permissions to write.
The permissions block refines or restricts permissions within the limits set by the repository settings. It cannot bypass those limits.

Examples of default_workflow_permissions in combination with gh-pages:
* https://github.com/eclipse-keypop/.eclipsefdn/blob/d302a93a17bc42ed08f6b65d70d220c601d6c4b8/otterdog/eclipse-keypop.jsonnet#L482
* https://github.com/eclipse-zenoh/.eclipsefdn/blob/44c59e2d14f68f4fa556f6fb622090a1d7890e5b/otterdog/eclipse-zenoh.jsonnet#L322
* https://github.com/eclipse-keyple/.eclipsefdn/blob/0a852bb5befffc7f9002008beb15b1d261e3ab52/otterdog/eclipse-keyple.jsonnet#L95
* https://github.com/eclipse-thingweb/.eclipsefdn/blob/c21814d81fe5f7bc06ffd58bd8b3ef661032fe52/otterdog/eclipse-thingweb.jsonnet#L50