### PR TITLE
score: environment configuation

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -336,7 +336,10 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       ],
       environments: [
         orgs.newEnvironment('github-pages') {
-          deployment_branch_policy: "all"
+          deployment_branch_policy: "all",
+          required_reviewers: [
+            "@eclipse-score/community-operational"
+          ],
         },
       ],
     },


### PR DESCRIPTION
Added reviewers to the github-pages env, so that they can manually trigger workflows (doc publishing) coming from forked PRs.