### PR TITLE
Add new repository for GCC toolchains

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -548,6 +548,25 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
+    orgs.newRepo('toolchains_gcc') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      description: "Bazel toolchains for GNU GCC",
+      homepage: "https://eclipse-score.github.io/toolchains_gcc",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: {
+            dismisses_stale_reviews: true,
+            required_approving_review_count: 1,
+            requires_code_owner_review: true,
+          },
+        },
+      ],
+    },
     orgs.newRepo('toolchains_qnx') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
The new repository will contain GNU GCC based toolchain versions.