### PR TITLE
Add new repostory for Rust toolchains

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -636,6 +636,25 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
+    orgs.newRepo('toolchains_rust') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      description: "Rust toolchains",
+      homepage: "https://eclipse-score.github.io/toolchains_rust",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: {
+            dismisses_stale_reviews: true,
+            required_approving_review_count: 1,
+            requires_code_owner_review: true,
+          },
+        },
+      ],
+    },
     orgs.newRepo('module_template') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
The new repostory shall contain configuration and build scripts for rust toolchains that for some targets like QNX need to be build from source or be adapted.

Rationale:
- Right now we don't have a publicly available Rust Toolchain / Compiler for QNX, this is a place to put build-scripts and Dockerfiles in for recipes that we cannot simply push to a public docker registry or to distribute as binaries.