### PR TITLE
New repository for toolchain GNU GCC packages

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -597,6 +597,25 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
+    orgs.newRepo('toolchains_gcc_packages') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      description: "Bazel toolchains for GNU GCC",
+      homepage: "https://eclipse-score.github.io/toolchains_gcc_packages",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: {
+            dismisses_stale_reviews: true,
+            required_approving_review_count: 1,
+            requires_code_owner_review: true,
+          },
+        },
+      ],
+    },
     orgs.newRepo('toolchains_qnx') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
Currently toolchain packages and Bazel configuration are on the same repository which could lead to release management issues. To avoid repetition, we want to split toolchain package release from Bazel configuration release.