### PR TITLE
Add team for infrastructure-maintainers

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -143,6 +143,12 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         "ramceb"
       ],
     },
+    orgs.newTeam('infrastructure-maintainers') {
+      members+: [
+        "AlexanderLanin",
+        "MaximilianSoerenPollak",
+      ],
+    },
   ],
   secrets+: [
     orgs.newOrgSecret('DEVELOCITY_API_TOKEN') {


### PR DESCRIPTION
A new team which can be used for CODEOWNERS, review assignments etc

While technically all committers have review rights across all repositories, realistically infrastructure is (and should be) maintained by the infrastructure experts.

Currently that's @AlexanderLanin and @MaximilianSoerenPollak 