### PR TITLE
Add repository for docs-as-code

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -735,5 +735,23 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
+    orgs.newRepo('docs-as-code)') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      description: "Contains docs-as-code tooling",
+      rulesets: [
+        orgs.newRepoRuleset('main') {
+          include_refs+: [
+            "refs/heads/main"
+          ],
+          required_pull_request+: {
+            dismisses_stale_reviews: true,
+            required_approving_review_count: 1,
+            requires_code_owner_review: true,
+          },
+        },
+      ],
+    },
   ],
 }


### PR DESCRIPTION
A repository that will contain all 'docs-as-code' tooling.