### PR TITLE
Remove 'process' repository

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -664,20 +664,6 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
-    orgs.newRepo('process') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      code_scanning_default_setup_enabled: true,
-      description: "Score process and docs-as-code repository",
-      rulesets: [
-        orgs.newRepoRuleset('main') {
-          include_refs+: [
-            "refs/heads/main"
-          ],
-          required_pull_request+: default_review_rule,
-        },
-      ],
-    },
     newInfrastructureTeamRepo('docs-as-code') {
       description: "Docs-as-code tooling for Eclipse S-CORE",
 


### PR DESCRIPTION
Removing the process repository as it's no longer needed. 

The items that were planned to be inside this repository are now split across 'docs-as-code' as well as 'process_description' 