### PR TITLE
Add JSON test data mirror

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -750,6 +750,20 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         has_wiki: true,
     },
 
+    newScoreRepo("json_test_data_mirror", false) {
+      description: "JSON test data mirror for nlohmann_json",
+      forked_repository: "nlohmann/json_test_data",
+      default_branch: "master",
+      rulesets: [
+        orgs.newRepoRuleset('master') {
+          include_refs+: [
+            "refs/heads/master"
+          ],
+          required_pull_request+: default_review_rule,
+        },
+      ],
+    },
+
     newInfrastructureTeamRepo('bazel_registry_ui') {
       description: "House the ui for bazel_registry in Score",
       gh_pages_build_type: "legacy",


### PR DESCRIPTION
The Trustable Software Framework (TSF) requires that tests must be constructed from controlled or mirrored sources and must be reproducible (see [TA-Tests](https://codethinklabs.gitlab.io/trustable/trustable/doorstop/TA.html#ta-tests)). The nlohmann_json library, which is planned to be [qualified using TSF](https://github.com/eclipse-score/baselibs/issues/146), relies on external test data from the [json_test_data](https://github.com/nlohmann/json_test_data) repository. To ensure compliance with the TSF, this test data repository should be forked and thereby mirrored.