### PR TITLE
logging: add logging repository for logging components

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -828,27 +828,8 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     newModuleRepo('bazel-tools-cc') {
       description: "Repository for clang-tidy based static code checker",
     },
-
     newModuleRepo('logging') {
-      allow_merge_commit: false,
-      allow_update_branch: false,
-      code_scanning_default_setup_enabled: false,
-      has_discussions: true,
-      has_wiki: false,
       description: "Repository for logging framework",
-      rulesets: [
-        orgs.newRepoRuleset('main') {
-          include_refs+: [
-            "refs/heads/main"
-          ],
-          required_pull_request+: default_review_rule,
-          bypass_actors+: [
-            "@eclipse-score/cft-logging",
-          ],
-          allows_force_pushes: false,
-          requires_linear_history: true,
-        },
-      ],
     },
   ],
 }


### PR DESCRIPTION
This commit introduces a dedicated logging repository to store all logging-related components. The frontend remains in baselibs due to its self-contained design.