### PR TITLE
qnx: exposed secrets to inc_mw_per

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -225,21 +225,24 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     },
     orgs.newOrgSecret('SCORE_QNX_LICENSE') {
       selected_repositories+: [
-        "toolchains_qnx"
+        "toolchains_qnx",
+        "inc_mw_per"
       ],
       value: "********",
       visibility: "selected",
     },
     orgs.newOrgSecret('SCORE_QNX_PASSWORD') {
       selected_repositories+: [
-        "toolchains_qnx"
+        "toolchains_qnx",
+        "inc_mw_per"
       ],
       value: "********",
       visibility: "selected",
     },
     orgs.newOrgSecret('SCORE_QNX_USER') {
       selected_repositories+: [
-        "toolchains_qnx"
+        "toolchains_qnx",
+        "inc_mw_per"
       ],
       value: "********",
       visibility: "selected",


### PR DESCRIPTION
We want to build for QNX as a target the repo inc_mw_per

Addresses: eclipse-score/score#1702