### PR TITLE
feat(itf): enable GitHub Pages

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -656,7 +656,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         orgs.newEnvironment('github-pages'),
       ],
     },
-    newInfrastructureTeamRepo('itf', subcategory = "integration") {
+    newInfrastructureTeamRepo('itf', pages = true, subcategory = "integration") {
       description: "Integration Testing Framework repository",
 
       # Deviations from standard newScoreRepo settings:


### PR DESCRIPTION
## Summary

- Sets `pages = true` on the `itf` repository configuration
- Enables workflow-based GitHub Pages (`gh_pages_build_type: workflow`)
- Adds `homepage: https://eclipse-score.github.io/itf`

## Test plan

- [ ] Verify otterdog plan shows only the expected diff on the `itf` repo (pages build type + homepage)
- [ ] After merge, confirm GitHub Pages is enabled in the `itf` repo settings