### PR TITLE
MCP Server mono - repo creation

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1186,6 +1186,9 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     newDependableElementRepo('scrample') {
       description: "Repository for example component",
     },
+    newDependableElementRepo('dev_playground') {
+      description: "Repository for developer tools and playground",
+    },
     newDependableElementRepo('inc_abi_compatible_datatypes') {
       description: "Incubation repository for ABI compatible data types feature",
     },

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1186,7 +1186,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     newDependableElementRepo('scrample') {
       description: "Repository for example component",
     },
-    newDependableElementRepo('dev_playground') {
+    newScoreRepo('dev_playground') {
       description: "Repository for developer tools and playground",
     },
     newDependableElementRepo('inc_abi_compatible_datatypes') {

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1248,11 +1248,8 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
-    newScoreRepo('ai-plugin-marketplace') {
-      description: "Repository for AI Marketplace metadata, channels, pinning strategy",
-    },
-    newScoreRepo('ai-plugins') {
-      description: "Repository for AI Plugins rolled out in the marketplace",
+    newScoreRepo('mcp_servers') {
+      description: "Repository for MCP servers",
     },
     
     newDependableElementRepo('logging') {

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1248,7 +1248,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
-    newScoreRepo('mcp_servers') {
+    newScoreRepo('mcp-servers') {
       description: "Repository for MCP servers",
     },
     

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1251,10 +1251,10 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         },
       ],
     },
-    newDependableElementRepo('ai-plugin-marketplace') {
+    newScoreRepo('ai-plugin-marketplace') {
       description: "Repository for AI Marketplace metadata, channels, pinning strategy",
     },
-    newDependableElementRepo('ai-plugins') {
+    newScoreRepo('ai-plugins') {
       description: "Repository for AI Plugins rolled out in the marketplace",
     },
     

--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1164,6 +1164,13 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     newDependableElementRepo('bazel-tools-cc') {
       description: "Repository for clang-tidy based static code checker",
     },
+    newDependableElementRepo('ai-plugin-marketplace') {
+      description: "Repository for AI Marketplace metadata, channels, pinning strategy",
+    },
+    newDependableElementRepo('ai-plugins') {
+      description: "Repository for AI Plugins rolled out in the marketplace",
+    },
+    
     newDependableElementRepo('logging') {
       description: "Repository for logging daemon",
 


### PR DESCRIPTION
## Summary

Create two new Eclipse SCORE repositories to support reusable AI runtime integration without bloating the governance overlay repo:

- `mcp_servers`: mcp server monorepo containing SCORE mcp servers.

## Why

This separates concerns cleanly:

- .github remains a thin governance and Copier-template overlay
- mcp server implementations are reusable across Copilot/VS Code, Codex, and Claude-compatible workflows

## Intended Usage

- Teams consume mcp server entries from `mcp_servers`