### PR TITLE
Enable QNX build for inc_time repo

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -98,6 +98,7 @@ local qnx_enabled_repos = [
     "communication",
     "ferrocene_toolchain_builder",
     "inc_someip_gateway",
+    "inc_time",
     "itf",
     "kyron",
     "lifecycle",


### PR DESCRIPTION
I'd like to enable the QNX build for the [`inc_time`](https://github.com/eclipse-score/inc_time) repo. Hope this is all what's needed.