### PR TITLE
Revert "Enforce clang-tidy job for communication"

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -931,7 +931,6 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
               "build_and_test_qnx",
               "build_and_test_asan_ubsan_lsan",
               "build_and_test_tsan",
-              "clang-tidy",
             ],
           },
           required_merge_queue: orgs.newMergeQueue() {


### PR DESCRIPTION
Reverts eclipse-score/.eclipsefdn#191

Since this was merged, we could not merge anything in score/communication.
PRs get removed with 'no response for status'.
I want to revert this to see if it is the cultprit.
For what I searched it seems that it might be an issue with mismatching job name and what it is expected as required. That the required job never is found and that is why it does not finish the merge.