### PR TITLE
Archive baselibs_rust

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1139,6 +1139,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
 
       # Deviations from standard dependable element repository settings:
       allow_update_branch: true,
+      archived: true,
       allow_rebase_merge: true,
       branch_protection_rules: [
         main_branch_protection_rule


### PR DESCRIPTION
As baselibs_rust were moved to baselibs
in https://github.com/eclipse-score/baselibs/pull/236 we archive repository

Part of: https://github.com/eclipse-score/baselibs/issues/200