### PR TITLE
Add communication-triage team with triage access to communication repo

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -416,6 +416,15 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         "AlexanderLanin",
       ],
     },
+    orgs.newTeam('communication-triage') {
+      members+: [
+        "gdadunashvili",
+        "sahithi-nukala",
+        "AAmbuj",
+        "soldier-sky",
+        "Rahul-Sutariya",
+      ],
+    },
   ],
   variables+: [
     orgs.newOrgVariable("ECLIPSE_PROJECT") {
@@ -896,6 +905,12 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
     },
     newDependableElementRepo('communication') {
       description: "Repository for the communication module LoLa",
+      teams+: [
+        {
+          name: 'communication-triage',
+          permission: 'triage',
+        },
+      ],
 
       # Deviations from standard dependable element repository settings:
       template_repository: null,


### PR DESCRIPTION
Add a new team 'communication-triage' with known members and grant it triage permission on the communication repository.

Triage is a read-level permission that allows managing issues, pull requests, and discussions without granting write access to code or repository settings. This is explicitly permitted by the Eclipse Foundation's IP and governance policies, as triage rights do not constitute commit or write access and therefore do not require committer status.

We need this to effectively triage bug tickets, GitHub Actions failures, and code quality findings at scale. As the communication module grows, the volume of incoming issues and CI notifications exceeds what the current committer team can handle in a timely manner. Dedicated triage members allow us to label, assign, and prioritize work without bottlenecking on committer availability.