### PR TITLE
fix: work around ottdog bug related to newRepoRuleset

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -487,7 +487,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         # overwrite default ruleset and allow admins (eclipse-score-bot) to push directly to main
         orgs.newRepoRuleset('main') {
           include_refs: ["~DEFAULT_BRANCH"],
-          required_pull_request: default_review_rule,
+          required_pull_request+: default_review_rule,
           bypass_actors: ["#OrganizationAdmin"],
           requires_linear_history: true,
         },


### PR DESCRIPTION
it seems that overwriting required_pull_request does not work, as that lost the requires_last_push_approval key.

All PRs since #190 show diff to live settings problems, and #190 was never applied.