### PR TITLE
communication: Update CI job names

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -927,11 +927,11 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
           allows_force_pushes: false,
           required_status_checks+: {
             status_checks+: [
-              "build_and_test_host",
-              "build_and_test_qnx",
-              "build_and_test_asan_ubsan_lsan",
-              "build_and_test_tsan",
-              "clang-tidy",
+              "GCC15 / Build & Test",
+              "QCC - Build & Test",
+              "Address & Undefined Behavior Sanitizer / Build & Test",
+              "Thread Sanitizer / Build & Test ",
+              "Clang-Tidy / Build & Test",
             ],
           },
           required_merge_queue: orgs.newMergeQueue() {


### PR DESCRIPTION
In order to have better readability, we give better names for the CI jobs.