### PR TITLE
 fix: allow tag-based Pages deployments for process_description

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -765,6 +765,15 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       allow_merge_commit: true,
       allow_rebase_merge: true,
       allow_update_branch: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main",
+            "tag:*",
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
     },
     newInfrastructureTeamRepo('reference_integration', true, subcategory = "integration") {
       description: "Score project integration repository",


### PR DESCRIPTION


  Add "tag:*" to the github-pages environment deployment branch
  policy. The environment previously only allowed deployments from
  main, which silently blocked release-triggered deployments since
  they run from tag refs (e.g. refs/tags/v2.0.0). The deploy-pages
  action reported success but GitHub Pages ignored the deployment.
