### PR TITLE
fix: allow tag-based Pages deployments for process_description

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -767,11 +767,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       allow_update_branch: false,
       environments: [
         orgs.newEnvironment('github-pages') {
-          branch_policies+: [
-            "main",
-            "tag:*",
-          ],
-          deployment_branch_policy: "selected",
+          deployment_branch_policy: "all",
         },
       ],
     },


### PR DESCRIPTION
Set github-pages environment deployment_branch_policy to "all". The "selected" policy with "tag:*" does not work for deploy-pages because environment protection rules only match branches, not tags (see actions/deploy-pages#76). Removing the restriction allows release workflows running from tag refs to deploy to GitHub Pages.