### PR TITLE
Feat: Add Utils Infra-repository

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -1064,6 +1064,14 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
       ],
     },
 
+    newInfrastructureTeamRepo('utils', pages = false, subcategory = "tooling") {
+      description: "Gathering of different utilities used throughout S-CORE",
+
+      environments+: [
+        orgs.newEnvironment('copilot'),
+      ],
+    },
+
     newDependableElementRepo('orchestrator') {
       description: "Orchestration framework & Safe async runtime for Rust",
 


### PR DESCRIPTION
Adding a utils infra repo to move some tools from the `tooling` repository. 
To allow for usage of these tools without having to inherit a lot of dependencies that are not needed, as is currently the case. 