### PR TITLE
communication: Disable default code scanning

### DIFF
--- a/otterdog/eclipse-score.jsonnet
+++ b/otterdog/eclipse-score.jsonnet
@@ -920,7 +920,7 @@ orgs.newOrg('automotive.score', 'eclipse-score') {
         "python",
         # "rust", # not yet supported by GH API: https://docs.github.com/en/rest/code-scanning/code-scanning?apiVersion=2022-11-28#update-a-code-scanning-default-setup-configuration
       ],
-      code_scanning_default_setup_enabled: true,
+      code_scanning_default_setup_enabled: false,
       has_discussions: true,
       rulesets: [
         orgs.newRepoRuleset('main') {


### PR DESCRIPTION
Since we have our own CodeQL run, that properly reports our C++ deficits, we cannot have in parallel the default code scanning enabled, since otherwise the advanced code scanning is not functional.